### PR TITLE
Change preg_match patern for support PHP 7.4

### DIFF
--- a/src/Traits/ValidatePackageName.php
+++ b/src/Traits/ValidatePackageName.php
@@ -24,7 +24,7 @@ trait ValidatePackageName
      */
     protected function validatePackageName($name)
     {
-        if (!preg_match('/^[\w-\/]+$/', $name)) {
+        if (!preg_match('/^[\w|\/]+$/', $name)) {
             throw new InvalidArgumentException('The package name can only contain letters, numbers, underscores, dashes and slashes.');
         }
 


### PR DESCRIPTION
if use this pattern `/^[\w-\/]+$/'` on `Jackiedo\Packager\Traits\ValidatePackageName@validatePackageName`, cause Error `preg_match(): Compilation failed: invalid range in character class at offset 4`
so i'am change this old pattern `/^[\w-\/]+$/'` to new pattern `/^[\w|\/]+$/`.

i'am sorry if my bad english ^_^.
im from indonesian.